### PR TITLE
LPS-58672 Fix regression caused by eaeafb5ba18da8d4ee5b8278627ba7b221…

### DIFF
--- a/journal-test/src/testIntegration/java/com/liferay/journal/lar/test/JournalFeedStagedModelDataHandlerTest.java
+++ b/journal-test/src/testIntegration/java/com/liferay/journal/lar/test/JournalFeedStagedModelDataHandlerTest.java
@@ -106,6 +106,9 @@ public class JournalFeedStagedModelDataHandlerTest
 			PortletPreferencesFactoryUtil.getPortalPreferences(
 				TestPropsValues.getUserId(), true);
 
+		_originalPortalPreferencesXML = PortletPreferencesFactoryUtil.toXML(
+			portalPreferenceces);
+
 		portalPreferenceces.setValue(
 			"", "publishToLiveByDefaultEnabled", "true");
 		portalPreferenceces.setValue(
@@ -122,11 +125,10 @@ public class JournalFeedStagedModelDataHandlerTest
 		portalPreferenceces.setValue(
 			"", "journalArticlePageBreakToken", "@page_break@");
 
-		_portalPreferences =
-			PortalPreferencesLocalServiceUtil.addPortalPreferences(
-				TestPropsValues.getCompanyId(),
-				PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-				PortletPreferencesFactoryUtil.toXML(portalPreferenceces));
+		PortalPreferencesLocalServiceUtil.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			PortletPreferencesFactoryUtil.toXML(portalPreferenceces));
 	}
 
 	@After
@@ -134,8 +136,10 @@ public class JournalFeedStagedModelDataHandlerTest
 	public void tearDown() throws Exception {
 		super.tearDown();
 
-		PortalPreferencesLocalServiceUtil.deletePortalPreferences(
-			_portalPreferences);
+		PortalPreferencesLocalServiceUtil.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			_originalPortalPreferencesXML);
 	}
 
 	@Override
@@ -314,7 +318,6 @@ public class JournalFeedStagedModelDataHandlerTest
 	}
 
 	private Layout _layout;
-	private com.liferay.portal.kernel.model.PortalPreferences
-		_portalPreferences;
+	private String _originalPortalPreferencesXML;
 
 }

--- a/journal-test/src/testIntegration/java/com/liferay/journal/lar/test/JournalPortletDataHandlerTest.java
+++ b/journal-test/src/testIntegration/java/com/liferay/journal/lar/test/JournalPortletDataHandlerTest.java
@@ -81,6 +81,9 @@ public class JournalPortletDataHandlerTest
 			PortletPreferencesFactoryUtil.getPortalPreferences(
 				TestPropsValues.getUserId(), true);
 
+		_originalPortalPreferencesXML = PortletPreferencesFactoryUtil.toXML(
+			portalPreferenceces);
+
 		portalPreferenceces.setValue(
 			"", "publishToLiveByDefaultEnabled", "true");
 		portalPreferenceces.setValue(
@@ -97,17 +100,18 @@ public class JournalPortletDataHandlerTest
 		portalPreferenceces.setValue(
 			"", "journalArticlePageBreakToken", "@page_break@");
 
-		_portalPreferences =
-			PortalPreferencesLocalServiceUtil.addPortalPreferences(
-				TestPropsValues.getCompanyId(),
-				PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-				PortletPreferencesFactoryUtil.toXML(portalPreferenceces));
+		PortalPreferencesLocalServiceUtil.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			PortletPreferencesFactoryUtil.toXML(portalPreferenceces));
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		PortalPreferencesLocalServiceUtil.deletePortalPreferences(
-			_portalPreferences);
+		PortalPreferencesLocalServiceUtil.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			_originalPortalPreferencesXML);
 	}
 
 	@Test
@@ -187,7 +191,6 @@ public class JournalPortletDataHandlerTest
 		return JournalPortletKeys.JOURNAL;
 	}
 
-	private com.liferay.portal.kernel.model.PortalPreferences
-		_portalPreferences;
+	private String _originalPortalPreferencesXML;
 
 }

--- a/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchTest.java
+++ b/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchTest.java
@@ -116,13 +116,15 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 			PortletPreferencesFactoryUtil.getPortalPreferences(
 				TestPropsValues.getUserId(), true);
 
+		_originalPortalPreferencesXML = PortletPreferencesFactoryUtil.toXML(
+			portalPreferenceces);
+
 		portalPreferenceces.setValue("", "articleCommentsEnabled", "true");
 
-		_portalPreferences =
-			PortalPreferencesLocalServiceUtil.addPortalPreferences(
-				TestPropsValues.getCompanyId(),
-				PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-				PortletPreferencesFactoryUtil.toXML(portalPreferenceces));
+		PortalPreferencesLocalServiceUtil.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			PortletPreferencesFactoryUtil.toXML(portalPreferenceces));
 
 		_journalServiceConfiguration =
 			ConfigurationProviderUtil.getCompanyConfiguration(
@@ -134,8 +136,10 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 
 	@After
 	public void tearDown() throws Exception {
-		PortalPreferencesLocalServiceUtil.deletePortalPreferences(
-			_portalPreferences);
+		PortalPreferencesLocalServiceUtil.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			_originalPortalPreferencesXML);
 	}
 
 	@Test
@@ -611,7 +615,6 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 	private DDMIndexer _ddmIndexer;
 	private DDMStructure _ddmStructure;
 	private JournalServiceConfiguration _journalServiceConfiguration;
-	private com.liferay.portal.kernel.model.PortalPreferences
-		_portalPreferences;
+	private String _originalPortalPreferencesXML;
 
 }

--- a/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalIndexerTest.java
+++ b/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalIndexerTest.java
@@ -101,22 +101,26 @@ public class JournalIndexerTest {
 			PortletPreferencesFactoryUtil.getPortalPreferences(
 				TestPropsValues.getUserId(), true);
 
+		_originalPortalPreferencesXML = PortletPreferencesFactoryUtil.toXML(
+			portalPreferenceces);
+
 		portalPreferenceces.setValue(
 			"", "indexAllArticleVersionsEnabled", "true");
 		portalPreferenceces.setValue(
 			"", "expireAllArticleVersionsEnabled", "true");
 
-		_portalPreferences =
-			PortalPreferencesLocalServiceUtil.addPortalPreferences(
-				TestPropsValues.getCompanyId(),
-				PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-				PortletPreferencesFactoryUtil.toXML(portalPreferenceces));
+		PortalPreferencesLocalServiceUtil.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			PortletPreferencesFactoryUtil.toXML(portalPreferenceces));
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		PortalPreferencesLocalServiceUtil.deletePortalPreferences(
-			_portalPreferences);
+		PortalPreferencesLocalServiceUtil.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			_originalPortalPreferencesXML);
 	}
 
 	@Test
@@ -857,7 +861,6 @@ public class JournalIndexerTest {
 	@DeleteAfterTestRun
 	private Group _group;
 
-	private com.liferay.portal.kernel.model.PortalPreferences
-		_portalPreferences;
+	private String _originalPortalPreferencesXML;
 
 }

--- a/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
+++ b/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
@@ -93,22 +93,26 @@ public class JournalArticleIndexVersionsTest {
 			PortletPreferencesFactoryUtil.getPortalPreferences(
 				TestPropsValues.getUserId(), true);
 
+		_originalPortalPreferencesXML = PortletPreferencesFactoryUtil.toXML(
+			portalPreferenceces);
+
 		portalPreferenceces.setValue(
 			"", "expireAllArticleVersionsEnabled", "true");
 		portalPreferenceces.setValue(
 			"", "indexAllArticleVersionsEnabled", "false");
 
-		_portalPreferences =
-			PortalPreferencesLocalServiceUtil.addPortalPreferences(
-				TestPropsValues.getCompanyId(),
-				PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-				PortletPreferencesFactoryUtil.toXML(portalPreferenceces));
+		PortalPreferencesLocalServiceUtil.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			PortletPreferencesFactoryUtil.toXML(portalPreferenceces));
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		PortalPreferencesLocalServiceUtil.deletePortalPreferences(
-			_portalPreferences);
+		PortalPreferencesLocalServiceUtil.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			_originalPortalPreferencesXML);
 	}
 
 	@Test
@@ -319,7 +323,6 @@ public class JournalArticleIndexVersionsTest {
 	@DeleteAfterTestRun
 	private Group _group;
 
-	private com.liferay.portal.kernel.model.PortalPreferences
-		_portalPreferences;
+	private String _originalPortalPreferencesXML;
 
 }

--- a/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleServiceTest.java
+++ b/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleServiceTest.java
@@ -124,14 +124,16 @@ public class JournalArticleServiceTest {
 			PortletPreferencesFactoryUtil.getPortalPreferences(
 				TestPropsValues.getUserId(), true);
 
+		_originalPortalPreferencesXML = PortletPreferencesFactoryUtil.toXML(
+			portalPreferenceces);
+
 		portalPreferenceces.setValue(
 			"", "expireAllArticleVersionsEnabled", "true");
 
-		_portalPreferences =
-			PortalPreferencesLocalServiceUtil.addPortalPreferences(
-				TestPropsValues.getCompanyId(),
-				PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-				PortletPreferencesFactoryUtil.toXML(portalPreferenceces));
+		PortalPreferencesLocalServiceUtil.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			PortletPreferencesFactoryUtil.toXML(portalPreferenceces));
 	}
 
 	@After
@@ -144,8 +146,10 @@ public class JournalArticleServiceTest {
 
 		PortalRunMode.setTestMode(_testMode);
 
-		PortalPreferencesLocalServiceUtil.deletePortalPreferences(
-			_portalPreferences);
+		PortalPreferencesLocalServiceUtil.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			_originalPortalPreferencesXML);
 	}
 
 	@Test
@@ -763,8 +767,7 @@ public class JournalArticleServiceTest {
 
 	private String _keyword;
 	private JournalArticle _latestArticle;
-	private com.liferay.portal.kernel.model.PortalPreferences
-		_portalPreferences;
+	private String _originalPortalPreferencesXML;
 	private boolean _testMode;
 
 }


### PR DESCRIPTION
…929d77, PortalPreference has a logic unique index on ownerId and owenType, you can not add a new PortalPreferences here, because there is already an exist PortalPreferences with the same values on ownerId and owerType, this must be an update. This is causing a stable failure when you run JournalArticleSearchTest and StagingLocalizationTest in a row.

@brianchandotcom this fixes the stable CI failures for StagingLocalizationTest on modules-integration-hypersonic, which was caused by eaeafb5ba18da8d4ee5b8278627ba7b221929d77 from https://github.com/brianchandotcom/liferay-portal/pull/42466

CC @pavel-savinov that was your pull, and you can see modules-integration-hypersonic started failing from your pull.

The changes in eaeafb5ba18da8d4ee5b8278627ba7b221929d77 creates PortalPreferences with duplicated ownerId + ownerType, which violates the logic unique index on it. Causing the following up StagingLocalizationTest fails to update and see the correct PortalPreferences. It only happens on hypersonic, because when doing a select without order by, there suppose to have no order guarantee about the returning result set. However different DBs have their own default sorting logic, it just happens to be Hypersonic's default logic is different from other DBs, making him the only one suffering from this issue. And we should actually thank him for doing this, otherwise we would not even notice this regression.

This pull only contains the minimal required parts on journal side to make the test pass, there will be more portal side changes coming in after this is merge, to prevent future regressions like this. And to ensure different DBs can have consistent results.

@juliocamarero please give this higher priority for review, as CI is failing on StagingLocalizationTest.