### PR TITLE
LPS-36174 Fix regression caused by cca23b47e74c6619ce11e72f7d309c21da…

### DIFF
--- a/journal-service/src/main/java/com/liferay/journal/service/permission/JournalFolderPermission.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/permission/JournalFolderPermission.java
@@ -95,6 +95,8 @@ public class JournalFolderPermission implements BaseModelPermissionChecker {
 			while (folderId !=
 						JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 
+				JournalFolder parentFolder = folder;
+
 				folder = _journalFolderLocalService.fetchFolder(folderId);
 
 				if (folder != null) {
@@ -103,7 +105,12 @@ public class JournalFolderPermission implements BaseModelPermissionChecker {
 					}
 				}
 				else {
-					if (!folder.isInTrash()) {
+					if (parentFolder.isInTrash()) {
+						folder = parentFolder;
+
+						break;
+					}
+					else {
 						_log.error(
 							"Unable to obtain JournalFolder with folderId" +
 								folderId);


### PR DESCRIPTION
…3c18c6

@juliocamarero in https://github.com/liferay/com-liferay-journal/commit/cca23b47e74c6619ce11e72f7d309c21da3c18c6 you changed the exception handling logic, that caused failures like these https://test-1-13.liferay.com/job/test-portal-acceptance-upstream-batch(master)/4673/AXIS_VARIABLE=8,label_exp=!master/testReport/ , so this is the fix.

In https://github.com/liferay/liferay-portal/pull/1067, your pull did pass, so my best guess is, CI is breaking now, that your pull was never running with your changes. This part @michaelhashimoto is digging into it now, he will give you some explanation later.

CC @brianchandotcom please merge this pull to make CI green again.