### PR TITLE
LPS-69295 Remove uses of IndexWriterHelperUtil in com-liferay-journal

### DIFF
--- a/journal-service/build.gradle
+++ b/journal-service/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.dao.orm.custom.sql", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.instance.lifecycle", version: "3.0.0"
+	provided group: "com.liferay", name: "com.liferay.portal.search", version: "3.4.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"

--- a/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
+++ b/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
@@ -47,9 +47,9 @@ import com.liferay.portal.kernel.search.DDMStructureIndexer;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.search.IndexWriterHelperUtil;
+import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.Indexer;
-import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
@@ -73,6 +73,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.index.IndexStatusManager;
 import com.liferay.trash.kernel.util.TrashUtil;
 
 import java.io.Serializable;
@@ -244,7 +245,7 @@ public class JournalArticleIndexer
 	public void reindexDDMStructures(List<Long> ddmStructureIds)
 		throws SearchException {
 
-		if (IndexWriterHelperUtil.isIndexReadOnly() || !isIndexerEnabled()) {
+		if (_indexStatusManager.isIndexReadOnly() || !isIndexerEnabled()) {
 			return;
 		}
 
@@ -262,7 +263,7 @@ public class JournalArticleIndexer
 			}
 
 			final Indexer<JournalArticle> indexer =
-				IndexerRegistryUtil.nullSafeGetIndexer(JournalArticle.class);
+				_indexerRegistry.nullSafeGetIndexer(JournalArticle.class);
 
 			final ActionableDynamicQuery actionableDynamicQuery =
 				_journalArticleLocalService.getActionableDynamicQuery();
@@ -440,7 +441,7 @@ public class JournalArticleIndexer
 			return;
 		}
 
-		IndexWriterHelperUtil.updateDocument(
+		_indexWriterHelper.updateDocument(
 			getSearchEngineId(), journalArticle.getCompanyId(),
 			getDocument(latestIndexableArticle), isCommitImmediately());
 	}
@@ -607,7 +608,7 @@ public class JournalArticleIndexer
 
 			Document document = getDocument(article);
 
-			IndexWriterHelperUtil.deleteDocument(
+			_indexWriterHelper.deleteDocument(
 				getSearchEngineId(), article.getCompanyId(),
 				document.get(Field.UID), isCommitImmediately());
 
@@ -865,7 +866,7 @@ public class JournalArticleIndexer
 	protected void reindexArticleVersions(JournalArticle article)
 		throws PortalException {
 
-		IndexWriterHelperUtil.updateDocuments(
+		_indexWriterHelper.updateDocuments(
 			getSearchEngineId(), article.getCompanyId(),
 			getArticleVersions(article), isCommitImmediately());
 	}
@@ -928,6 +929,16 @@ public class JournalArticleIndexer
 	private DDMIndexer _ddmIndexer;
 	private DDMStructureLocalService _ddmStructureLocalService;
 	private FieldsToDDMFormValuesConverter _fieldsToDDMFormValuesConverter;
+
+	@Reference
+	private IndexerRegistry _indexerRegistry;
+
+	@Reference
+	private IndexStatusManager _indexStatusManager;
+
+	@Reference
+	private IndexWriterHelper _indexWriterHelper;
+
 	private JournalArticleLocalService _journalArticleLocalService;
 	private JournalArticleResourceLocalService
 		_journalArticleResourceLocalService;

--- a/journal-service/src/main/java/com/liferay/journal/search/JournalFolderIndexer.java
+++ b/journal-service/src/main/java/com/liferay/journal/search/JournalFolderIndexer.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.search.BaseIndexer;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.FolderIndexer;
-import com.liferay.portal.kernel.search.IndexWriterHelperUtil;
+import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.Summary;
@@ -149,7 +149,7 @@ public class JournalFolderIndexer
 	protected void doReindex(JournalFolder journalFolder) throws Exception {
 		Document document = getDocument(journalFolder);
 
-		IndexWriterHelperUtil.updateDocument(
+		_indexWriterHelper.updateDocument(
 			getSearchEngineId(), journalFolder.getCompanyId(), document,
 			isCommitImmediately());
 	}
@@ -211,6 +211,9 @@ public class JournalFolderIndexer
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalFolderIndexer.class);
+
+	@Reference
+	private IndexWriterHelper _indexWriterHelper;
 
 	private JournalFolderLocalService _journalFolderLocalService;
 


### PR DESCRIPTION
Enforce use of OSGi References to prevent a race condition that may rarely skip journal articles when index on startup is enabled.

https://issues.liferay.com/browse/LPS-69295