### PR TITLE
LRQA-29747 Change property values to match modified target names

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -10,7 +10,7 @@
 ##
 
     test.batch.names=\
-        subrepository-functional-tomcat8-mysql56-jdk8,\
+        subrepository-functional-tomcat80-mysql56-jdk8,\
         subrepository-integration-mysql56-jdk8
 
-    test.batch.run.property.query[subrepository-functional-tomcat8-mysql56-jdk8]=portal.acceptance == true AND testray.main.component.name ~ "Web Content"
+    test.batch.run.property.query[subrepository-functional-tomcat80-mysql56-jdk8]=portal.acceptance == true AND testray.main.component.name ~ "Web Content"


### PR DESCRIPTION
http://issues.liferay.com/browse/LRQA-29747

@juliocamarero This commit is to fix the errors currently happening in the journal pullrequest. I had renamed some ant target names in the portal repository, but had forgotten to rename the properties that need to match up with these targets. Sorry for the inconvenience.

cc @pyoo47 @michaelhashimoto 