### PR TITLE
LPS-69801 Deprecate instead of change API (match 7.0.x version)

### DIFF
--- a/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6619,6 +6619,20 @@ public class JournalArticleLocalServiceImpl
 		newArticle.setContent(contentDocument.formattedString());
 	}
 
+	/**
+	* @deprecated As of 3.4.0, replaced by {@link #createFieldsValuesMap(
+	*  Element, Locale)}
+	*/
+	@Deprecated
+	protected Map<String, LocalizedValue> createFieldsValuesMap(
+		Element parentElement) {
+
+		Locale defaultLocale = LocaleUtil.fromLanguageId(
+			parentElement.attributeValue("default-locale"));
+
+		return createFieldsValuesMap(parentElement, defaultLocale);
+	}
+
 	protected Map<String, LocalizedValue> createFieldsValuesMap(
 		Element parentElement, Locale defaultLocale) {
 


### PR DESCRIPTION
This is needed so backport to ee-7.0.x doesn't need a major version increase, and to improve backwards compatibility.

/cc @jcampoy 