### PR TITLE
LPS-70608 Adding a new upgrade process to convert content for journal images to Liferay 7 format

### DIFF
--- a/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_1/UpgradeImageTypeContentAttributes.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_1/UpgradeImageTypeContentAttributes.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.internal.upgrade.v1_0_1;
+
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.Node;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.kernel.xml.XPath;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.List;
+
+/**
+ * @author Alberto Chaparro
+ */
+public class UpgradeImageTypeContentAttributes extends UpgradeProcess {
+
+	protected String addImageContentAttributes(String content)
+		throws Exception {
+
+		Document contentDocument = SAXReaderUtil.read(content);
+
+		contentDocument = contentDocument.clone();
+
+		XPath xPath = SAXReaderUtil.createXPath(
+			"//dynamic-element[@type='image']");
+
+		List<Node> imageNodes = xPath.selectNodes(contentDocument);
+
+		for (Node imageNode : imageNodes) {
+			Element imageEl = (Element)imageNode;
+
+			List<Element> dynamicContentEls = imageEl.elements(
+				"dynamic-content");
+
+			for (Element dynamicContentEl : dynamicContentEls) {
+				String id = dynamicContentEl.attributeValue("id");
+
+				dynamicContentEl.addAttribute("alt", StringPool.BLANK);
+				dynamicContentEl.addAttribute("name", id);
+				dynamicContentEl.addAttribute("title", id);
+				dynamicContentEl.addAttribute("type", "journal");
+			}
+		}
+
+		return contentDocument.formattedString();
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		updateContentImages();
+	}
+
+	protected void updateContentImages() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer();
+			PreparedStatement ps1 = connection.prepareStatement(
+				"select content, id_ from JournalArticle where content like " +
+					"?")) {
+
+			ps1.setString(1, "%type=\"image\"%");
+
+			ResultSet rs = ps1.executeQuery();
+
+			while (rs.next()) {
+				String content = rs.getString(1);
+				long id = rs.getLong(2);
+
+				String newContent = addImageContentAttributes(content);
+
+				try (PreparedStatement ps =
+						AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+							connection,
+							"update JournalArticle set content = ? where id_ " +
+								"= ?")) {
+
+					ps.setString(1, newContent);
+					ps.setLong(2, id);
+
+					ps.executeUpdate();
+				}
+			}
+		}
+	}
+
+}

--- a/journal-service/src/main/java/com/liferay/journal/upgrade/JournalServiceUpgrade.java
+++ b/journal-service/src/main/java/com/liferay/journal/upgrade/JournalServiceUpgrade.java
@@ -32,6 +32,7 @@ import com.liferay.journal.internal.upgrade.v0_0_5.UpgradeJournalDisplayPreferen
 import com.liferay.journal.internal.upgrade.v0_0_5.UpgradeLastPublishDate;
 import com.liferay.journal.internal.upgrade.v0_0_5.UpgradePortletSettings;
 import com.liferay.journal.internal.upgrade.v1_0_0.UpgradeJournalArticleImage;
+import com.liferay.journal.internal.upgrade.v1_0_1.UpgradeImageTypeContentAttributes;
 import com.liferay.journal.internal.upgrade.v1_1_0.UpgradeDocumentLibraryTypeContent;
 import com.liferay.journal.internal.upgrade.v1_1_0.UpgradeImageTypeContent;
 import com.liferay.journal.internal.upgrade.v1_1_0.UpgradeJournalArticleLocalizedValues;
@@ -121,7 +122,11 @@ public class JournalServiceUpgrade implements UpgradeStepRegistrator {
 			new UpgradeJournalArticleImage());
 
 		registry.register(
-			"com.liferay.journal.service", "1.0.0", "1.1.0",
+			"com.liferay.journal.service", "1.0.0", "1.0.1",
+			new UpgradeImageTypeContentAttributes());
+
+		registry.register(
+			"com.liferay.journal.service", "1.0.1", "1.1.0",
 			new UpgradeDocumentLibraryTypeContent(_dlAppLocalService),
 			new UpgradeImageTypeContent(_imageLocalService),
 			new UpgradeJournalArticleLocalizedValues());

--- a/journal-service/src/main/java/com/liferay/journal/verify/JournalServiceVerifyProcess.java
+++ b/journal-service/src/main/java/com/liferay/journal/verify/JournalServiceVerifyProcess.java
@@ -16,11 +16,7 @@ package com.liferay.journal.verify;
 
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
-import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.dynamic.data.mapping.exception.NoSuchStructureException;
-import com.liferay.dynamic.data.mapping.model.DDMStructure;
-import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
-import com.liferay.dynamic.data.mapping.storage.Fields;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
 import com.liferay.journal.internal.verify.model.JournalArticleResourceVerifiableModel;
 import com.liferay.journal.internal.verify.model.JournalArticleVerifiableModel;
@@ -34,7 +30,6 @@ import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.service.JournalArticleResourceLocalService;
 import com.liferay.journal.service.JournalContentSearchLocalService;
 import com.liferay.journal.service.JournalFolderLocalService;
-import com.liferay.journal.util.JournalConverter;
 import com.liferay.journal.util.comparator.ArticleVersionComparator;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
@@ -47,21 +42,17 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
@@ -80,7 +71,6 @@ import java.sql.Timestamp;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 
 import javax.portlet.PortletPreferences;
 
@@ -134,25 +124,6 @@ public class JournalServiceVerifyProcess extends VerifyLayout {
 	}
 
 	@Reference(unbind = "-")
-	protected void setCompanyLocalService(
-		CompanyLocalService companyLocalService) {
-
-		_companyLocalService = companyLocalService;
-	}
-
-	@Reference(unbind = "-")
-	protected void setDDMStructureLocalService(
-		DDMStructureLocalService ddmStructureLocalService) {
-
-		_ddmStructureLocalService = ddmStructureLocalService;
-	}
-
-	@Reference(unbind = "-")
-	protected void setDLAppLocalService(DLAppLocalService dlAppLocalService) {
-		_dlAppLocalService = dlAppLocalService;
-	}
-
-	@Reference(unbind = "-")
 	protected void setJournalArticleLocalService(
 		JournalArticleLocalService journalArticleLocalService) {
 
@@ -172,11 +143,6 @@ public class JournalServiceVerifyProcess extends VerifyLayout {
 		JournalContentSearchLocalService journalContentSearchLocalService) {
 
 		_journalContentSearchLocalService = journalContentSearchLocalService;
-	}
-
-	@Reference(unbind = "-")
-	protected void setJournalConverter(JournalConverter journalConverter) {
-		_journalConverter = journalConverter;
 	}
 
 	@Reference(unbind = "-")
@@ -294,48 +260,6 @@ public class JournalServiceVerifyProcess extends VerifyLayout {
 
 				_journalArticleLocalService.updateJournalArticle(article);
 			}
-		}
-	}
-
-	protected void updateDynamicElements(JournalArticle article)
-		throws Exception {
-
-		if (Validator.isNull(article.getDDMStructureKey())) {
-			return;
-		}
-
-		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
-			article.getGroupId(), _portal.getClassNameId(JournalArticle.class),
-			article.getDDMStructureKey(), true);
-
-		Locale originalefaultLocale = LocaleThreadLocal.getDefaultLocale();
-		Locale originalSiteDefaultLocale =
-			LocaleThreadLocal.getSiteDefaultLocale();
-
-		try {
-			Company company = _companyLocalService.getCompany(
-				article.getCompanyId());
-
-			LocaleThreadLocal.setDefaultLocale(company.getLocale());
-
-			LocaleThreadLocal.setSiteDefaultLocale(
-				_portal.getSiteDefaultLocale(article.getGroupId()));
-
-			Fields ddmFields = _journalConverter.getDDMFields(
-				ddmStructure, article.getContent());
-
-			String content = _journalConverter.getContent(
-				ddmStructure, ddmFields);
-
-			if (!content.equals(article.getContent())) {
-				article.setContent(content);
-
-				_journalArticleLocalService.updateJournalArticle(article);
-			}
-		}
-		finally {
-			LocaleThreadLocal.setDefaultLocale(originalefaultLocale);
-			LocaleThreadLocal.setSiteDefaultLocale(originalSiteDefaultLocale);
 		}
 	}
 
@@ -685,16 +609,6 @@ public class JournalServiceVerifyProcess extends VerifyLayout {
 									article.getId(),
 								e);
 						}
-
-						try {
-							updateDynamicElements(article);
-						}
-						catch (Exception e) {
-							_log.error(
-								"Unable to update content for article " +
-									article.getId(),
-								e);
-						}
 					}
 
 				});
@@ -894,14 +808,10 @@ public class JournalServiceVerifyProcess extends VerifyLayout {
 		JournalServiceVerifyProcess.class);
 
 	private AssetEntryLocalService _assetEntryLocalService;
-	private CompanyLocalService _companyLocalService;
-	private DDMStructureLocalService _ddmStructureLocalService;
-	private DLAppLocalService _dlAppLocalService;
 	private JournalArticleLocalService _journalArticleLocalService;
 	private JournalArticleResourceLocalService
 		_journalArticleResourceLocalService;
 	private JournalContentSearchLocalService _journalContentSearchLocalService;
-	private JournalConverter _journalConverter;
 	private JournalFolderLocalService _journalFolderLocalService;
 
 	@Reference


### PR DESCRIPTION
Hi,

After working some days in this ticket we have decided the following approach to solve this issue:

1. Create a new upgrade process to convert old image fields into the liferay 7 format (journal schema version 1.0.1)
2. Remove the call to journalConverter API in VerifyProcess. This call is causing this bug but apart from that, it's a bug nest since anytime we perform an upgrade we execute the XML conversion with journal XML from different sources (6.0.x, 6.1.x, 6.2.x or 7.0.x) so with different formats that the logic doesn't expect. The only way to convert XML format among versions is using upgrade processes since they are designed for one specific Liferay version.

To be able to remove the JournalConverter call we have ensure that the following bugs which required that logic are still fixed:
https://issues.liferay.com/browse/LPS-51534 (we don't need index fields in Liferay 7 anymore)
https://issues.liferay.com/browse/LPS-62755 (we don't need index fields in Liferay 7 anymore)
https://issues.liferay.com/browse/LPS-67429 (this use case is working well with the new changes)
https://issues.liferay.com/browse/LPS-70554 (it's solved without using the verifyProcess by LPS-66971)

Different upgrade tests from 6.0.12, 6.1.30 and 6.2.10 worked well with the new changes.

Thanks.

cc @ealonso @migue