### PR TITLE
LPS-71907

### DIFF
--- a/journal-service/build.gradle
+++ b/journal-service/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.subscription.api", version: "1.0.0-20170308.171906-1"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.24.0-20170327.224758-1"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.27.0-20170417.181333-2"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
 	provided group: "commons-lang", name: "commons-lang", version: "2.1"

--- a/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalPortletDataHandler.java
+++ b/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalPortletDataHandler.java
@@ -129,6 +129,11 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 		return true;
 	}
 
+	@Override
+	public boolean isSupportsDataStrategyMirrorWithOverwriting() {
+		return false;
+	}
+
 	@Activate
 	protected void activate() {
 		setDataLocalized(true);


### PR DESCRIPTION
Re-sent from https://github.com/liferay/com-liferay-journal/pull/238. Updated the portal-kernel dependency to the latest snapshot of 2.27 instead of default (2.27 is where the new API appears, and it wasn't published until yesterday).

/cc @jonathanmccann @SamZiemer

> Relevant tickets:
> https://issues.liferay.com/browse/LPP-24514
> https://issues.liferay.com/browse/LPS-71907
> https://issues.liferay.com/browse/LPS-71050 (depends on new API from this ticket)
> 
> This is largely a revised re-send from jonathanmccann#12, but I figured since it depends on changes from the already resolved [LPS-71050](https://issues.liferay.com/browse/LPS-71050), it would be best to open [LPS-71907](https://issues.liferay.com/browse/LPS-71907) as a new LPS. It's also been quite a while since that pull request was closed.
> 
> LPS-71050 adds API to portal-kernel to allow PortletDataHandlers to disable the "Mirror with overwriting" import strategy option if it's not implemented. This pull leverages this to disable the option, since even if it will be implemented at some point, for now it is not; if it's implemented, then this can simply be changed back to return "true," re-enabling the strategy. We are targeting this use case (Web Content imports) for a customer-specific issue.