### PR TITLE
[TECHNICAL-SUPPORT] LPS-72234 Cannot export Web Content if Small Image URL is set

### DIFF
--- a/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalArticleExportImportContentProcessor.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalArticleExportImportContentProcessor.java
@@ -123,7 +123,18 @@ public class JournalArticleExportImportContentProcessor
 			return content;
 		}
 
-		Document document = SAXReaderUtil.read(content);
+		Document document = null;
+
+		try {
+			document = SAXReaderUtil.read(content);
+		}
+		catch (DocumentException de) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Invalid content:\n" + content);
+			}
+
+			return content;
+		}
 
 		XPath xPath = SAXReaderUtil.createXPath(
 			"//dynamic-element[@type='ddm-journal-article']");

--- a/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalArticleStagedModelDataHandlerTest.java
+++ b/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalArticleStagedModelDataHandlerTest.java
@@ -141,6 +141,20 @@ public class JournalArticleStagedModelDataHandlerTest
 	}
 
 	@Test
+	public void testArticleWithSmallImageURL() throws Exception {
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			stagingGroup.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		journalArticle.setSmallImage(true);
+		journalArticle.setSmallImageURL(RandomTestUtil.randomString());
+
+		journalArticle = JournalTestUtil.updateArticle(journalArticle);
+
+		exportImportStagedModel(journalArticle);
+	}
+
+	@Test
 	public void testCompanyScopeDependencies() throws Exception {
 		initExport();
 


### PR DESCRIPTION
Hi guys,

the root cause of the problem is that in [JournalArticleStagedModelDataHandler ](https://github.com/moltam89/com-liferay-journal/blob/master/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java#L309) the _JournalArticleExportImportContentProcessor_ is invoked, which assumes that the content is a valid XML.

However, in case of the small image URL the logic in _JournalArticleExportImportContentProcessor_ cannot be applied, the _BaseTextExportImportContentProcessor_ is responsible to handle the possible references to DL file entries.

Cheers,
Tamás

