### PR TITLE
LRQA-32434 Break the integration tests into 7 different axis builds

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -22,3 +22,5 @@
 		(testray.component.names ~ "Web Content") OR \
 		(testray.main.component.name ~ "Web Content")\
 	)
+
+	test.batch.size[subrepository-integration-mysql56-jdk8]=7


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-32434

@ealonso 
Currently there are about 700 integration tests that are all running on one VM.  We found that this one batch takes longer than any of the other functional batches, so we've decided to split them up into 7 different batches. (This arbitrary number is based on trying to put about 100 integration tests per VM.)

Let us know if you have any questions.  Thanks!

cc @lesliewong92 