### PR TITLE
[TECHNICAL-SUPPORT] LPS-70518 Referecing an edited article imported with resource importer makes Site Template import validation fail

### DIFF
--- a/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -196,7 +196,7 @@ public class JournalArticleStagedModelDataHandler
 			return referenceAttributes;
 		}
 
-		boolean preloaded = false;
+		boolean preloaded = isPreloadedArticle(defaultUserId, article);
 
 		if (defaultUserId == article.getUserId()) {
 			preloaded = true;
@@ -945,6 +945,27 @@ public class JournalArticleStagedModelDataHandler
 
 		return _journalArticleLocalService.fetchArticle(
 			groupId, articleId, version);
+	}
+
+	protected boolean isPreloadedArticle(
+		long defaultUserId, JournalArticle article) {
+
+		if (defaultUserId == article.getUserId()) {
+			return true;
+		}
+
+		JournalArticle preLoadedJournalArticle =
+			_journalArticleLocalService.fetchArticle(
+				article.getGroupId(), article.getArticleId(),
+				JournalArticleConstants.VERSION_DEFAULT);
+
+		if ((preLoadedJournalArticle != null) &&
+			(defaultUserId == preLoadedJournalArticle.getUserId())) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	@Reference(unbind = "-")

--- a/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -198,10 +198,6 @@ public class JournalArticleStagedModelDataHandler
 
 		boolean preloaded = isPreloadedArticle(defaultUserId, article);
 
-		if (defaultUserId == article.getUserId()) {
-			preloaded = true;
-		}
-
 		referenceAttributes.put("preloaded", String.valueOf(preloaded));
 
 		return referenceAttributes;
@@ -954,13 +950,12 @@ public class JournalArticleStagedModelDataHandler
 			return true;
 		}
 
-		JournalArticle preLoadedJournalArticle =
-			_journalArticleLocalService.fetchArticle(
-				article.getGroupId(), article.getArticleId(),
-				JournalArticleConstants.VERSION_DEFAULT);
+		JournalArticle firstArticle = _journalArticleLocalService.fetchArticle(
+			article.getGroupId(), article.getArticleId(),
+			JournalArticleConstants.VERSION_DEFAULT);
 
-		if ((preLoadedJournalArticle != null) &&
-			(defaultUserId == preLoadedJournalArticle.getUserId())) {
+		if ((firstArticle != null) &&
+			(defaultUserId == firstArticle.getUserId())) {
 
 			return true;
 		}

--- a/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -376,7 +376,7 @@ public class JournalArticleStagedModelDataHandler
 		long defaultUserId = _userLocalService.getDefaultUserId(
 			article.getCompanyId());
 
-		if (defaultUserId == article.getUserId()) {
+		if (isPreloadedArticle(defaultUserId, article)) {
 			articleElement.addAttribute("preloaded", "true");
 		}
 

--- a/journal-test/src/testIntegration/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/journal-test/src/testIntegration/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -270,6 +270,15 @@ public class JournalTestUtil {
 		serviceContext.setLayoutFullURL("http://localhost");
 
 		return addArticle(
+			groupId, folderId, articleId, autoArticleId, serviceContext);
+	}
+
+	public static JournalArticle addArticle(
+			long groupId, long folderId, String articleId,
+			boolean autoArticleId, ServiceContext serviceContext)
+		throws Exception {
+
+		return addArticle(
 			groupId, folderId, JournalArticleConstants.CLASSNAME_ID_DEFAULT,
 			articleId, autoArticleId,
 			_getLocalizedMap(RandomTestUtil.randomString()),


### PR DESCRIPTION
Hi guys,

this fix handles quite a unique problem with exporting/importing an edited preloaded journal article.

**The issue in a nutshell:**
We can have the same preloaded contents in different instances.
This needs extra attention from export/import point of view, as the preloaded contents won't share the same UUID.
The export process determines whether the content is preloaded. During the import we look for the preloaded flag and if it is found, a different logic is responsible to find the content, which doesn't use the UUID.

We consider the contents preloaded, if they were created by the default user.
However, in case of journal articles, when we edit a preloaded content, the new article version won't be created by the default user, so it won't be considered as preloaded. 
Therefore when we export/import such an edited preloaded journal article, the import will fail to find the already existing articleResource by the UUID, which results in creating a completely new article, instead of updating the already existing one.

The best solution would be to check the articleResource's userId to decide whether the article was preloaded or not, however unfortunately there is no userId column in the articleResource table.
As a best effort this fix checks whether the first article version was preloaded or not.

**Note:**
We don't have the same problem with other entities (DDMStructure/DDMTemplate, DLFIleEntryType) where we can have preloaded content, as editing them won't change the original userId.

Thanks,
Tamás