### PR TITLE
LPS-72839 SF

### DIFF
--- a/journal-content-search-web/src/main/java/com/liferay/journal/content/search/web/internal/upgrade/JournalContentSearchWebUpgrade.java
+++ b/journal-content-search-web/src/main/java/com/liferay/journal/content/search/web/internal/upgrade/JournalContentSearchWebUpgrade.java
@@ -15,7 +15,6 @@
 package com.liferay.journal.content.search.web.internal.upgrade;
 
 import com.liferay.journal.content.search.web.internal.constants.JournalContentSearchPortletKeys;
-import com.liferay.journal.content.search.web.internal.upgrade.v1_0_1.UpgradePortletId;
 import com.liferay.portal.kernel.upgrade.BaseUpgradePortletId;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;

--- a/journal-content-search-web/src/main/java/com/liferay/journal/content/search/web/internal/upgrade/JournalContentSearchWebUpgrade.java
+++ b/journal-content-search-web/src/main/java/com/liferay/journal/content/search/web/internal/upgrade/JournalContentSearchWebUpgrade.java
@@ -53,7 +53,7 @@ public class JournalContentSearchWebUpgrade implements UpgradeStepRegistrator {
 
 		registry.register(
 			"com.liferay.journal.content.search.web", "1.0.0", "1.0.1",
-			new UpgradePortletId());
+			new DummyUpgradeStep());
 	}
 
 }

--- a/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_1/UpgradeJournalContentSearch.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_1/UpgradeJournalContentSearch.java
@@ -33,9 +33,12 @@ public class UpgradeJournalContentSearch extends UpgradeProcess {
 
 	protected void upgradePortletId() throws Exception {
 		try (PreparedStatement ps1 = connection.prepareStatement(
-				"select contentSearchId, portletId from JournalContentSearch " +
-					"where portletId like '56%'");
-			PreparedStatement ps2 =
+				"select * from JournalContentSearch where portletId like '56%'");
+			PreparedStatement ps2 = connection.prepareStatement(
+				"select contentSearchId from JournalContentSearch where " +
+					"groupId = ? AND privateLayout = ? AND layoutId = ? AND " +
+						"portletId = ? AND articleId = ?");
+			PreparedStatement ps3 =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,
 					"update JournalContentSearch set portletId = ? where " +
@@ -44,19 +47,42 @@ public class UpgradeJournalContentSearch extends UpgradeProcess {
 
 			while (rs.next()) {
 				long contentSearchId = rs.getLong("contentSearchId");
+				long groupId = rs.getLong("groupId");
+				boolean privateLayout = rs.getBoolean("privateLayout");
+				long layoutId = rs.getLong("layoutId");
 				String portletId = rs.getString("portletId");
+				String articleId = rs.getString("articleId");
 
 				String newPortletId = StringUtil.replaceFirst(
 					portletId, _OLD_ROOT_PORTLET_ID, _NEW_ROOT_PORTLET_ID);
 
-				ps2.setString(1, newPortletId);
+				ps2.setLong(1, groupId);
 
-				ps2.setLong(2, contentSearchId);
+				ps2.setBoolean(2, privateLayout);
 
-				ps2.addBatch();
+				ps2.setLong(3, layoutId);
+
+				ps2.setString(4, newPortletId);
+
+				ps2.setString(5, articleId);
+
+				try (ResultSet rs2 = ps2.executeQuery()) {
+					if (rs2.next()) {
+						runSQL(
+							"delete from JournalContentSearch where " +
+								"contentSearchId = " + contentSearchId);
+					}
+					else {
+						ps3.setString(1, newPortletId);
+
+						ps3.setLong(2, contentSearchId);
+
+						ps3.addBatch();
+					}
+				}
 			}
 
-			ps2.executeBatch();
+			ps3.executeBatch();
 		}
 	}
 

--- a/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_1/UpgradeJournalContentSearch.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_1/UpgradeJournalContentSearch.java
@@ -24,7 +24,7 @@ import java.sql.ResultSet;
 /**
  * @author Jonathan McCann
  */
-public class UpgradePortletId extends UpgradeProcess {
+public class UpgradeJournalContentSearch extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {

--- a/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_1/UpgradeJournalContentSearch.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_1/UpgradeJournalContentSearch.java
@@ -33,7 +33,8 @@ public class UpgradeJournalContentSearch extends UpgradeProcess {
 
 	protected void upgradePortletId() throws Exception {
 		try (PreparedStatement ps1 = connection.prepareStatement(
-				"select * from JournalContentSearch where portletId like '56%'");
+				"select * from JournalContentSearch where portletId like " +
+					"'56%'");
 			PreparedStatement ps2 = connection.prepareStatement(
 				"select contentSearchId from JournalContentSearch where " +
 					"groupId = ? AND privateLayout = ? AND layoutId = ? AND " +

--- a/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_1/UpgradeJournalContentSearch.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_1/UpgradeJournalContentSearch.java
@@ -33,7 +33,8 @@ public class UpgradeJournalContentSearch extends UpgradeProcess {
 
 	protected void upgradePortletId() throws Exception {
 		try (PreparedStatement ps1 = connection.prepareStatement(
-				"select contentSearchId, portletId from JournalContentSearch");
+				"select contentSearchId, portletId from JournalContentSearch " +
+					"where portletId like '56%'");
 			PreparedStatement ps2 =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,

--- a/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_1/UpgradePortletId.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_1/UpgradePortletId.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.journal.content.search.web.internal.upgrade.v1_0_1;
+package com.liferay.journal.internal.upgrade.v1_0_1;
 
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;

--- a/journal-service/src/main/java/com/liferay/journal/upgrade/JournalServiceUpgrade.java
+++ b/journal-service/src/main/java/com/liferay/journal/upgrade/JournalServiceUpgrade.java
@@ -33,6 +33,7 @@ import com.liferay.journal.internal.upgrade.v0_0_5.UpgradeLastPublishDate;
 import com.liferay.journal.internal.upgrade.v0_0_5.UpgradePortletSettings;
 import com.liferay.journal.internal.upgrade.v0_0_6.UpgradeImageTypeContentAttributes;
 import com.liferay.journal.internal.upgrade.v1_0_0.UpgradeJournalArticleImage;
+import com.liferay.journal.internal.upgrade.v1_0_1.UpgradeJournalContentSearch;
 import com.liferay.journal.internal.upgrade.v1_1_0.UpgradeDocumentLibraryTypeContent;
 import com.liferay.journal.internal.upgrade.v1_1_0.UpgradeImageTypeContent;
 import com.liferay.journal.internal.upgrade.v1_1_0.UpgradeJournalArticleLocalizedValues;
@@ -127,7 +128,11 @@ public class JournalServiceUpgrade implements UpgradeStepRegistrator {
 			new UpgradeImageTypeContentAttributes());
 
 		registry.register(
-			"com.liferay.journal.service", "1.0.0", "1.1.0",
+			"com.liferay.journal.service", "1.0.0", "1.0.1",
+			new UpgradeJournalContentSearch());
+
+		registry.register(
+			"com.liferay.journal.service", "1.0.1", "1.1.0",
 			new UpgradeDocumentLibraryTypeContent(_dlAppLocalService),
 			new UpgradeImageTypeContent(_imageLocalService),
 			new UpgradeJournalArticleLocalizedValues());


### PR DESCRIPTION
Hi @jonathanmccann, @ealonso,

We can't define upgrades which modify the database tables using SQL in modules which those tables do not belong to for several reasons:
- One module does not have to know the database schema defined by other module. We should only use API to communicate between them. If we do that we would be adding a non declared dependency.
- The module journal-content-search-web doesn't have a associated schemaVersion like modules which define a database schema:
https://github.com/liferay/com-liferay-journal/blob/master/journal-service/bnd.bnd#L23

For that reason I moved the upgrade process from journal-content-search-web to journal-service:
https://github.com/liferay/com-liferay-journal/pull/355/commits/4eeeb8d6363f33a5eb9187f5c68e2961494fce5f

Please, take into account this for the future.

Thanks.
Best regards.