### PR TITLE
[TECHNICAL-SUPPORT] LPS-73948 forwarding resourceRequest and resourceResponse to create valid PortletRequestModel

### DIFF
--- a/journal-web/src/main/java/com/liferay/journal/web/util/JournalRSSUtil.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/util/JournalRSSUtil.java
@@ -434,8 +434,8 @@ public class JournalRSSUtil {
 
 			try {
 				value = processContent(
-					feed, article, languageId, themeDisplay, syndEntry,
-					syndContent);
+					resourceRequest, resourceResponse, feed, article,
+					languageId, themeDisplay, syndEntry, syndContent);
 			}
 			catch (Exception e) {
 				if (_log.isWarnEnabled()) {
@@ -562,7 +562,24 @@ public class JournalRSSUtil {
 		return null;
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, replaced by
+	 * 		{@link #processContent(ResourceRequest, ResourceResponse,
+	 * 		JournalFeed, JournalArticle, String, ThemeDisplay, SyndEntry,
+	 * 		SyndContent)}
+	 */
+	@Deprecated
 	protected String processContent(
+			JournalFeed feed, JournalArticle article, String languageId,
+			ThemeDisplay themeDisplay, SyndEntry syndEntry,
+			SyndContent syndContent)
+			throws Exception {
+
+		return StringPool.BLANK;
+	}
+
+	protected String processContent(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse,
 			JournalFeed feed, JournalArticle article, String languageId,
 			ThemeDisplay themeDisplay, SyndEntry syndEntry,
 			SyndContent syndContent)
@@ -582,7 +599,7 @@ public class JournalRSSUtil {
 			JournalArticleDisplay articleDisplay = _journalContent.getDisplay(
 				feed.getGroupId(), article.getArticleId(),
 				ddmRendererTemplateKey, null, languageId, 1,
-				new PortletRequestModel() {
+				new PortletRequestModel(resourceRequest, resourceResponse) {
 
 					@Override
 					public String toXML() {


### PR DESCRIPTION
Hi,

I'd like you to have a look at this fix of https://issues.liferay.com/browse/LPS-73948 .

The usage of the PortletRequestModel in JournalRSSUtil isn't complete. Using the default constructor instead of giving it a PortletRequest generates NPEs if we want to display RSS. This is the only usage of the default constructor as far as I can see.

Changing the PortletRequestModel's internal behaviour to prevent the NPEs would defeat the purpose of having the offending fields in the constructor and creating a PortletRequestModel for the RSS' sake without it having any content seems like a hacky way.

So we should supply the PortletRequest and PortletResponse when displaying RSS also.

My solution will give it the missing portletRequest, but the question remains if this can be solved in a simpler way.

What is your opinion?

Thanks in advance,
Balazs

@moltam89, @lipusz