### PR TITLE
J cords lps 73925 revised

### DIFF
--- a/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
+++ b/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
@@ -203,12 +203,17 @@ public class JournalArticleIndexer
 
 		boolean head = GetterUtil.getBoolean(
 			searchContext.getAttribute("head"), Boolean.TRUE);
+		boolean latest = GetterUtil.getBoolean(
+			searchContext.getAttribute("latest"));
 		boolean relatedClassName = GetterUtil.getBoolean(
 			searchContext.getAttribute("relatedClassName"));
 		boolean showNonindexable = GetterUtil.getBoolean(
 			searchContext.getAttribute("showNonindexable"));
 
-		if (head && !relatedClassName && !showNonindexable) {
+		if (latest && !relatedClassName && !showNonindexable) {
+			contextBooleanFilter.addRequiredTerm("latest", Boolean.TRUE);
+		}
+		else if (head && !relatedClassName && !showNonindexable) {
 			contextBooleanFilter.addRequiredTerm("head", Boolean.TRUE);
 		}
 

--- a/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
+++ b/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
@@ -524,6 +524,10 @@ public class JournalArticleIndexer
 
 		document.addKeyword("headListable", headListable);
 
+		boolean latestArticle = JournalUtil.isLatestArticle(journalArticle);
+
+		document.addKeyword("latest", latestArticle);
+
 		// Scheduled listable articles should be visible in asset browser
 
 		if (journalArticle.isScheduled() && headListable) {

--- a/journal-service/src/main/java/com/liferay/journal/util/impl/JournalUtil.java
+++ b/journal-service/src/main/java/com/liferay/journal/util/impl/JournalUtil.java
@@ -837,6 +837,20 @@ public class JournalUtil {
 		return false;
 	}
 
+	public static boolean isLatestArticle(JournalArticle article) {
+		JournalArticle latestArticle =
+			JournalArticleLocalServiceUtil.fetchLatestArticle(
+				article.getResourcePrimKey(), WorkflowConstants.STATUS_ANY);
+
+		if ((latestArticle != null) &&
+			(article.getId() == latestArticle.getId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	public static boolean isSubscribedToArticle(
 		long companyId, long groupId, long userId, long articleId) {
 

--- a/journal-service/src/main/java/com/liferay/journal/util/impl/JournalUtil.java
+++ b/journal-service/src/main/java/com/liferay/journal/util/impl/JournalUtil.java
@@ -840,7 +840,8 @@ public class JournalUtil {
 	public static boolean isLatestArticle(JournalArticle article) {
 		JournalArticle latestArticle =
 			JournalArticleLocalServiceUtil.fetchLatestArticle(
-				article.getResourcePrimKey(), WorkflowConstants.STATUS_ANY);
+				article.getResourcePrimKey(), WorkflowConstants.STATUS_ANY,
+				false);
 
 		if ((latestArticle != null) &&
 			(article.getId() == latestArticle.getId())) {

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1265,7 +1265,6 @@ public class JournalDisplayContext {
 		attributes.put("ddmStructureKey", ddmStructureKey);
 		attributes.put("ddmTemplateKey", ddmTemplateKey);
 		attributes.put("params", params);
-
 		searchContext.setAttributes(attributes);
 
 		searchContext.setCompanyId(companyId);

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1284,6 +1284,7 @@ public class JournalDisplayContext {
 		}
 
 		searchContext.setAttribute("head", !showVersions);
+		searchContext.setAttribute("latest", !showVersions);
 		searchContext.setAttribute("params", params);
 
 		if (!showVersions) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-73925
https://issues.liferay.com/browse/LPP-26392

This is continued from here: liferay/com-liferay-journal#430
I've changed the logic to keep the isHead logic, but added "latest" for isLatestArticle.

The expected behavior for search in the Web Content Portlet is:
A User can search for latest version of the article if it is Approved, Pending, Draft, Expired, ... but not In-Trash.