### PR TITLE
LPS-73925 Re-adjust code on account of LPS-74389

### DIFF
--- a/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
+++ b/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
@@ -217,7 +217,10 @@ public class JournalArticleIndexer
 			contextBooleanFilter.addRequiredTerm("head", Boolean.TRUE);
 		}
 
-		if (!relatedClassName && showNonindexable) {
+		if (latest && !relatedClassName && showNonindexable) {
+			contextBooleanFilter.addRequiredTerm("latest", Boolean.TRUE);
+		}
+		else if (!relatedClassName && showNonindexable) {
 			contextBooleanFilter.addRequiredTerm("headListable", Boolean.TRUE);
 		}
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-73925

Commits for LPS-73925 where already committed however another ticket - LPS-74389, also made changes which broke the committed changes. LPS-74389 utilized the "showNonindexable" attribute [here](https://github.com/liferay/liferay-portal/commit/e24ce7bed32353b8319e9cb88482253aae8a437b#diff-60658287e70540bfcee062d56a7ddc5aR1176) which removed the pending results previously added to LPS-73925. I'm adding an additional commit for this ticket to correct the behavior so results are consistent for both LPS's when the showNonindexable attribute is used.

