### PR TITLE
LPS-74678 Recycle Bin - Web Contents with review date stop the automatic check articles process

### DIFF
--- a/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6531,14 +6531,21 @@ public class JournalArticleLocalServiceImpl
 
 		for (JournalArticle article : articles) {
 			long groupId = article.getGroupId();
+
+			int status = article.getStatus();
+
+			if (article.getStatus() != WorkflowConstants.STATUS_IN_TRASH) {
+				status = WorkflowConstants.STATUS_ANY;
+			}
+
 			String articleId = article.getArticleId();
 			double version = article.getVersion();
 
 			if (!journalArticleLocalService.isLatestVersion(
-					groupId, articleId, version)) {
+					groupId, articleId, version, status)) {
 
 				article = journalArticleLocalService.getLatestArticle(
-					groupId, articleId);
+					groupId, articleId, status);
 			}
 
 			if (!latestArticles.contains(article)) {


### PR DESCRIPTION
Hi guys,

currently if we put an article where the Review Date is set to the Recycle Bin, the _checkArticlesByReviewDate_ method stops with a **NoSuchArticleException** exception, as it tries to find the latest version which is not in the trash, however there isn't any.

I think there are two ways to fix this issue:

1. Ignore articles in the Recycle Bin and do not send notifications
2. Extend the logic to handle those article which are in the Recycle Bin

I chose the 2. option, as for me it makes sense to set up e.g. a Review Date 30 days from now and put the article to the trash until that time.
Furthermore if we would ignore the articles in the trash, it would possible that the review date was passed, and no notifications would be sent even though if someone has restored the article afterwards.

Could you please review the changes?

Thanks,
Tamás