### PR TITLE
LPS-75090 Revert "LPS-72074 articleId and elName is not unique so the update can cause unique constraint violation on index IX_103D6207"

### DIFF
--- a/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_0/UpgradeJournalArticleImage.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_0_0/UpgradeJournalArticleImage.java
@@ -38,21 +38,24 @@ public class UpgradeJournalArticleImage extends UpgradeProcess {
 	protected void updateJournalArticleImagesInstanceId() throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer();
 			PreparedStatement ps1 = connection.prepareStatement(
-				"select articleImageId from JournalArticleImage where " +
-					"(elInstanceId = '' or elInstanceId is null)");
+				"select articleId, elName from JournalArticleImage where " +
+					"(elInstanceId = '' or elInstanceId is null) group by " +
+						"articleId, elName");
 			ResultSet rs = ps1.executeQuery()) {
 
 			try (PreparedStatement ps2 =
 					AutoBatchPreparedStatementUtil.autoBatch(
 						connection.prepareStatement(
 							"update JournalArticleImage set elInstanceId = ? " +
-								"where articleImageId = ?"))) {
+								"where articleId = ? and elName = ?"))) {
 
 				while (rs.next()) {
-					String articleImageId = rs.getString(1);
+					String articleId = rs.getString(1);
+					String elName = rs.getString(2);
 
 					ps2.setString(1, StringUtil.randomString(4));
-					ps2.setString(2, articleImageId);
+					ps2.setString(2, articleId);
+					ps2.setString(3, elName);
 
 					ps2.addBatch();
 				}


### PR DESCRIPTION
@ealonso, as we talked, we have reverted this because the changes for LPS-72074 caused a regression. We wanted to fix it in another way but after checking it with @NorbertKocsis, there is no way to reproduce it  so far. It seems an issue with one specific database with inconsistencies.

Thanks!

cc/ @jorgediaz-lr 