### PR TITLE
LPS-75328 extract xml version before replacing all invalid DDMFormFie…

### DIFF
--- a/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournal.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournal.java
@@ -523,6 +523,14 @@ public class UpgradeJournal extends UpgradeProcess {
 		Map<String, String> invalidDDMFormFieldNamesMap =
 			getInvalidDDMFormFieldNamesMap(content);
 
+		StringBundler sb = new StringBundler(2);
+
+		int xmlEndIndex = content.indexOf("?>") + 2;
+
+		sb.append(content.substring(0, xmlEndIndex));
+
+		content = content.substring(xmlEndIndex);
+
 		for (Map.Entry<String, String> entry :
 				invalidDDMFormFieldNamesMap.entrySet()) {
 
@@ -530,7 +538,9 @@ public class UpgradeJournal extends UpgradeProcess {
 				content, entry.getKey(), entry.getValue());
 		}
 
-		return content;
+		sb.append(content);
+
+		return sb.toString();
 	}
 
 	protected void updateJournalArticle(


### PR DESCRIPTION
During the journal service upgrade, we rename any DDMFormFieldNames that have punctuation in them. However, we do a blanket StringUtil.replace and replace any instance of the invalid name.

If a DDMFormFieldName has been named 1.0 this will lead all instances of 1.0 in the entire content string to be replaced with 10, including the xml version. After this, we can no longer access the content stored within the content string.

This fix extracts the xml version tag before doing the string replacement to avoid this issue.