### PR TITLE
LPS-75328 Match pattern when replacing

### DIFF
--- a/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournal.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournal.java
@@ -523,6 +523,14 @@ public class UpgradeJournal extends UpgradeProcess {
 		Map<String, String> invalidDDMFormFieldNamesMap =
 			getInvalidDDMFormFieldNamesMap(content);
 
+		StringBundler sb = new StringBundler(2);
+
+		int xmlEndIndex = content.indexOf("?>") + 2;
+
+		sb.append(content.substring(0, xmlEndIndex));
+
+		content = content.substring(xmlEndIndex);
+
 		for (Map.Entry<String, String> entry :
 				invalidDDMFormFieldNamesMap.entrySet()) {
 
@@ -530,7 +538,9 @@ public class UpgradeJournal extends UpgradeProcess {
 				content, entry.getKey(), entry.getValue());
 		}
 
-		return content;
+		sb.append(content);
+
+		return sb.toString();
 	}
 
 	protected void updateJournalArticle(

--- a/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournal.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournal.java
@@ -523,24 +523,15 @@ public class UpgradeJournal extends UpgradeProcess {
 		Map<String, String> invalidDDMFormFieldNamesMap =
 			getInvalidDDMFormFieldNamesMap(content);
 
-		StringBundler sb = new StringBundler(2);
-
-		int xmlEndIndex = content.indexOf("?>") + 2;
-
-		sb.append(content.substring(0, xmlEndIndex));
-
-		content = content.substring(xmlEndIndex);
-
 		for (Map.Entry<String, String> entry :
 				invalidDDMFormFieldNamesMap.entrySet()) {
 
 			content = StringUtil.replace(
-				content, entry.getKey(), entry.getValue());
+				content, "name=\"" + entry.getKey() + "\"",
+				"name=\"" + entry.getValue() + "\"");
 		}
 
-		sb.append(content);
-
-		return sb.toString();
+		return content;
 	}
 
 	protected void updateJournalArticle(


### PR DESCRIPTION
Hi @SamZiemer, we propose this fix. We replace following _nameAttributePattern (which uses name to find Invalid DDM Form Field Names), so it will replace entries like `name="1.0"` and not `version="1.0"`

Please let us know what you think