### PR TITLE
LPS-76048 Handling translations in document_library fields in web contents

### DIFF
--- a/journal-service/src/main/java/com/liferay/journal/verify/JournalServiceVerifyProcess.java
+++ b/journal-service/src/main/java/com/liferay/journal/verify/JournalServiceVerifyProcess.java
@@ -326,34 +326,37 @@ public class JournalServiceVerifyProcess extends VerifyLayout {
 	}
 
 	protected void updateDocumentLibraryElements(Element element) {
-		Element dynamicContentElement = element.element("dynamic-content");
+		List<Element> dynamicContentEl = element.elements("dynamic-content");
 
-		String path = dynamicContentElement.getStringValue();
+		for (Element dynamicContentElement : dynamicContentEl) {
 
-		String[] pathArray = StringUtil.split(path, CharPool.SLASH);
+			String path = dynamicContentElement.getStringValue();
 
-		if (pathArray.length != 5) {
-			return;
-		}
+			String[] pathArray = StringUtil.split(path, CharPool.SLASH);
 
-		long groupId = GetterUtil.getLong(pathArray[2]);
-		long folderId = GetterUtil.getLong(pathArray[3]);
-		String title = _http.decodeURL(HtmlUtil.escape(pathArray[4]));
+			if (pathArray.length != 5) {
+				return;
+			}
 
-		try {
-			FileEntry fileEntry = _dlAppLocalService.getFileEntry(
-				groupId, folderId, title);
+			long groupId = GetterUtil.getLong(pathArray[2]);
+			long folderId = GetterUtil.getLong(pathArray[3]);
+			String title = _http.decodeURL(HtmlUtil.escape(pathArray[4]));
 
-			Node node = dynamicContentElement.node(0);
+			try {
+				FileEntry fileEntry = _dlAppLocalService.getFileEntry(
+					groupId, folderId, title);
 
-			node.setText(path + StringPool.SLASH + fileEntry.getUuid());
-		}
-		catch (PortalException pe) {
+				Node node = dynamicContentElement.node(0);
 
-			// LPS-52675
+				node.setText(path + StringPool.SLASH + fileEntry.getUuid());
+			}
+			catch (PortalException pe) {
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(pe, pe);
+				// LPS-52675
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(pe, pe);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hi,

Can you review this pull request, please?

The issue is only reproducible in 7.0.x and not master because after [LPS-67119](https://issues.liferay.com/browse/LPS-67119) and [LPS-70523](https://issues.liferay.com/browse/LPS-70523) we have moved the procedure of update document library fields in web content from the JournalServiceVerifyProcess to UpgradeDocumentLibraryTypeContent. In such upgrade process [we are already considering all the posible translations](https://github.com/liferay/liferay-portal/blob/master/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeDocumentLibraryTypeContent.java#L71-L81), but we don't do it in the verify process in 7.0.x.

Thanks in advance.